### PR TITLE
fix: close remaining hardware-spec parser and synthesis gaps

### DIFF
--- a/crates/logicaffeine_compile/src/codegen_sva/fol_to_sva.rs
+++ b/crates/logicaffeine_compile/src/codegen_sva/fol_to_sva.rs
@@ -58,6 +58,14 @@ pub fn synthesize_sva_from_spec(spec: &str, clock: &str) -> Result<SynthesizedSv
 
     let body = sva_body;
 
+    // Reject degenerate synthesis results — these indicate the spec is not
+    // a temporal property (e.g., bare action sentences like "The bus acknowledges the request.")
+    if body.trim() == "0" {
+        return Err("Not a temporal property: this sentence describes an action or event, \
+            not a verifiable hardware property. Wrap in a temporal operator \
+            (e.g., \"Always, ...\") or restructure as a conditional.".to_string());
+    }
+
     // Determine assertion kind from the temporal operator
     let kind = if body.contains("s_eventually") || body.contains("cover") {
         "cover"

--- a/crates/logicaffeine_compile/src/codegen_sva/fol_to_sva.rs
+++ b/crates/logicaffeine_compile/src/codegen_sva/fol_to_sva.rs
@@ -103,6 +103,7 @@ fn synthesize_from_ast<'a>(
                 TemporalOperator::Always => inner, // G is implicit in assert property
                 TemporalOperator::Eventually => format!("s_eventually({})", inner),
                 TemporalOperator::Next => format!("nexttime({})", inner),
+                TemporalOperator::BoundedEventually(n) => format!("##[0:{}] {}", n, inner),
                 _ => inner,
             }
         }

--- a/crates/logicaffeine_language/src/ast/logic.rs
+++ b/crates/logicaffeine_language/src/ast/logic.rs
@@ -173,6 +173,9 @@ pub enum TemporalOperator {
     Eventually,
     /// Next: X(φ) — φ holds at the immediate next state.
     Next,
+    /// Bounded Eventually: F≤n(φ) — φ holds within n steps.
+    /// SVA target: `##[0:n] φ`
+    BoundedEventually(u32),
 }
 
 /// Binary temporal operators (LTL).

--- a/crates/logicaffeine_language/src/debug.rs
+++ b/crates/logicaffeine_language/src/debug.rs
@@ -198,7 +198,8 @@ impl<'a> DisplayWith for LogicExpr<'a> {
                     TemporalOperator::Past => "P",
                     TemporalOperator::Future => "F",
                     TemporalOperator::Always => "G",
-                    TemporalOperator::Eventually => "F",
+                    TemporalOperator::Eventually
+                    | TemporalOperator::BoundedEventually(_) => "F",
                     TemporalOperator::Next => "X",
                 };
                 write!(f, "{}({})", op, body.with(interner))

--- a/crates/logicaffeine_language/src/formatter.rs
+++ b/crates/logicaffeine_language/src/formatter.rs
@@ -99,6 +99,7 @@ pub trait LogicFormatter {
             TemporalOperator::Future => self.future(),
             TemporalOperator::Always => "G",
             TemporalOperator::Eventually => "F",
+            TemporalOperator::BoundedEventually(n) => return format!("F≤{}({})", n, body),
             TemporalOperator::Next => "X",
         };
         format!("{}({})", sym, body)

--- a/crates/logicaffeine_language/src/lexer.rs
+++ b/crates/logicaffeine_language/src/lexer.rs
@@ -1915,6 +1915,16 @@ impl<'a> Lexer<'a> {
             }
         }
 
+        // "Exactly N" → Cardinal(N) — same as bare number but explicit
+        if lower == "exactly" {
+            if let Some(num_word) = self.peek_word(1) {
+                if let Some(n) = Self::word_to_number(num_word) {
+                    self.consume_words(1);
+                    return TokenType::Cardinal(n);
+                }
+            }
+        }
+
         if let Some(n) = Self::word_to_number(&lower) {
             return TokenType::Cardinal(n);
         }

--- a/crates/logicaffeine_language/src/parser/clause.rs
+++ b/crates/logicaffeine_language/src/parser/clause.rs
@@ -117,6 +117,23 @@ impl<'a, 'ctx, 'int> ClauseParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
             }
         }
 
+        // "While X, Y" as temporal duration subordinator
+        // Duration semantics: Y holds for the entire interval where X is true.
+        // Lowered as implication checked globally: G(X → Y)
+        if self.check(&TokenType::While) {
+            self.advance(); // consume "While"
+            let condition = self.parse_sentence()?;
+            if self.check(&TokenType::Comma) {
+                self.advance();
+            }
+            let consequent = self.parse_sentence()?;
+            return Ok(self.ctx.exprs.alloc(LogicExpr::BinaryOp {
+                left: condition,
+                op: TokenType::Implies,
+                right: consequent,
+            }));
+        }
+
         // "When X, Y" as temporal subordinator (before wh-question check)
         // Disambiguate: subordinator has comma-separated clauses, question does not
         if self.check(&TokenType::When) {
@@ -205,6 +222,36 @@ impl<'a, 'ctx, 'int> ClauseParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
             }));
         }
 
+        // "not both every request is valid and every grant is valid" → ¬(X ∧ Y)
+        // Only triggers for clausal conjunction: "both" + quantifier/determiner
+        // NOT for conjoined NP: "both Socrates and Plato are men"
+        if self.check(&TokenType::Both) {
+            // Peek at token after "both" — if it's a quantifier, this is clausal
+            let next_is_clausal = if self.current + 1 < self.tokens.len() {
+                matches!(self.tokens[self.current + 1].kind,
+                    TokenType::All | TokenType::No | TokenType::Some | TokenType::Any
+                    | TokenType::Most | TokenType::Few | TokenType::Many
+                    | TokenType::Cardinal(_) | TokenType::AtLeast(_) | TokenType::AtMost(_)
+                    | TokenType::Article(_)
+                )
+            } else {
+                false
+            };
+            if next_is_clausal {
+                self.advance(); // consume "both"
+                let first = self.parse_atom()?;
+                if self.check(&TokenType::And) {
+                    self.advance(); // consume "and"
+                }
+                let second = self.parse_atom()?;
+                return Ok(self.ctx.exprs.alloc(LogicExpr::BinaryOp {
+                    left: first,
+                    op: TokenType::And,
+                    right: second,
+                }));
+            }
+        }
+
         // Sentence-initial temporal operators for hardware verification:
         // "Always, P" → Temporal { Always, P }
         // "Eventually, P" → Temporal { Eventually, P }
@@ -265,9 +312,32 @@ impl<'a, 'ctx, 'int> ClauseParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
 
         // "After X, Y" → X → Y (temporal sequence)
         // "Before X, Y" → Y → X
+        // Handles both "After reset is deasserted, ..." (full clause)
+        // and "After request, ..." (bare signal/event noun)
         if self.check_preposition_is("after") || self.check_preposition_is("After") {
             self.advance(); // consume "after"
-            let antecedent = self.parse_sentence()?;
+
+            // Check for bare noun/signal + comma pattern: "After request, ..."
+            // Also handle Performative tokens (e.g., "request" when not after determiner)
+            let is_bare_noun_comma = self.current + 1 < self.tokens.len()
+                && matches!(self.tokens[self.current + 1].kind, TokenType::Comma)
+                && (self.check_content_word()
+                    || matches!(self.peek().kind, TokenType::Performative(_)));
+            let antecedent = if is_bare_noun_comma {
+                let noun = match self.advance().kind.clone() {
+                    TokenType::Performative(s) => s,
+                    TokenType::Noun(s) | TokenType::Adjective(s) | TokenType::ProperName(s) => s,
+                    TokenType::Verb { lemma, .. } => lemma,
+                    _ => return Err(crate::error::ParseError {
+                        kind: crate::error::ParseErrorKind::ExpectedContentWord { found: self.peek().kind.clone() },
+                        span: self.current_span(),
+                    }),
+                };
+                self.ctx.exprs.alloc(LogicExpr::Atom(noun))
+            } else {
+                self.parse_sentence()?
+            };
+
             if self.check(&TokenType::Comma) {
                 self.advance();
             }

--- a/crates/logicaffeine_language/src/parser/clause.rs
+++ b/crates/logicaffeine_language/src/parser/clause.rs
@@ -342,6 +342,7 @@ impl<'a, 'ctx, 'int> ClauseParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
                 self.advance();
             }
             let consequent = self.parse_sentence()?;
+            let consequent = self.try_wrap_bounded_delay(consequent);
             return Ok(self.ctx.exprs.alloc(LogicExpr::BinaryOp {
                 left: antecedent,
                 op: TokenType::Implies,
@@ -1263,6 +1264,9 @@ impl<'a, 'ctx, 'int> ClauseParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
                 right,
             });
         }
+
+        // Check for trailing "within N cycles" bounded temporal delay
+        let expr = self.try_wrap_bounded_delay(expr);
 
         Ok(expr)
     }

--- a/crates/logicaffeine_language/src/parser/mod.rs
+++ b/crates/logicaffeine_language/src/parser/mod.rs
@@ -98,11 +98,12 @@ pub enum ParserMode {
     Imperative,
 }
 
-/// Temporal modifier after copula: "is always Y" or "is never Y".
+/// Temporal modifier after copula: "is always Y", "is never Y", "is eventually Y".
 #[derive(Debug, Clone, Copy)]
-enum CopulaTemporal {
+pub(super) enum CopulaTemporal {
     Always,
     Never,
+    Eventually,
 }
 
 /// Controls scope of negation for lexically negative verbs (lacks, miss).
@@ -7106,6 +7107,9 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                     if resolved == "Always" || resolved == "always" {
                         self.advance();
                         copula_temporal = Some(CopulaTemporal::Always);
+                    } else if resolved == "Eventually" || resolved == "eventually" {
+                        self.advance();
+                        copula_temporal = Some(CopulaTemporal::Eventually);
                     }
                 }
             }
@@ -7603,6 +7607,12 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                     self.ctx.exprs.alloc(LogicExpr::Temporal {
                         operator: TemporalOperator::Always,
                         body: negated,
+                    })
+                }
+                Some(CopulaTemporal::Eventually) => {
+                    self.ctx.exprs.alloc(LogicExpr::Temporal {
+                        operator: TemporalOperator::Eventually,
+                        body: result,
                     })
                 }
                 None => result,
@@ -9308,7 +9318,8 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
             | TokenType::NonIntersectiveAdjective(_)
             | TokenType::Verb { .. }
             | TokenType::ProperName(_)
-            | TokenType::Article(_) => true,
+            | TokenType::Article(_)
+            | TokenType::Performative(_) => true,
             TokenType::Ambiguous { primary, alternatives } => {
                 Self::is_content_word_type(primary)
                     || alternatives.iter().any(Self::is_content_word_type)
@@ -9326,6 +9337,7 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                 | TokenType::Verb { .. }
                 | TokenType::ProperName(_)
                 | TokenType::Article(_)
+                | TokenType::Performative(_)
         )
     }
 
@@ -9805,10 +9817,12 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                 Ok(s)
             }
             TokenType::Verb { lemma, .. } => Ok(lemma),
+            TokenType::Performative(s) => Ok(s),
             TokenType::Ambiguous { primary, .. } => {
                 match *primary {
                     TokenType::Noun(s) | TokenType::Adjective(s) | TokenType::NonIntersectiveAdjective(s) => Ok(s),
                     TokenType::Verb { lemma, .. } => Ok(lemma),
+                    TokenType::Performative(s) => Ok(s),
                     TokenType::ProperName(s) => {
                         // In imperative mode, proper names must be defined
                         if self.mode == ParserMode::Imperative {

--- a/crates/logicaffeine_language/src/parser/mod.rs
+++ b/crates/logicaffeine_language/src/parser/mod.rs
@@ -9048,6 +9048,12 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
 
             let mut pp_predicates: Vec<&'a LogicExpr<'a>> = Vec::new();
             while self.check_preposition() || self.check_to() {
+                // "within N cycles" is a temporal bound, not a PP
+                if self.check_preposition_is("within") && self.current + 1 < self.tokens.len()
+                    && matches!(self.tokens[self.current + 1].kind, TokenType::Cardinal(_) | TokenType::Number(_))
+                {
+                    break;
+                }
                 let prep_token = self.advance().clone();
                 let prep_name = if let TokenType::Preposition(sym) = prep_token.kind {
                     sym
@@ -9339,6 +9345,41 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                 | TokenType::Article(_)
                 | TokenType::Performative(_)
         )
+    }
+
+    /// Check for trailing "within N cycles" and wrap in BoundedEventually.
+    pub(super) fn try_wrap_bounded_delay(&mut self, expr: &'a LogicExpr<'a>) -> &'a LogicExpr<'a> {
+        if !self.check_preposition_is("within") {
+            return expr;
+        }
+        let has_number = if self.current + 1 < self.tokens.len() {
+            matches!(self.tokens[self.current + 1].kind, TokenType::Cardinal(_) | TokenType::Number(_))
+        } else {
+            false
+        };
+        if !has_number {
+            return expr;
+        }
+        self.advance(); // consume "within"
+        let bound = match self.advance().kind {
+            TokenType::Cardinal(n) => n,
+            TokenType::Number(sym) => {
+                let n_str = self.interner.resolve(sym);
+                n_str.parse::<u32>().unwrap_or(1)
+            }
+            _ => 1,
+        };
+        // Consume optional "cycle" / "cycles"
+        if self.check_content_word() {
+            let word = self.interner.resolve(self.peek().lexeme).to_lowercase();
+            if word == "cycle" || word == "cycles" {
+                self.advance();
+            }
+        }
+        self.ctx.exprs.alloc(LogicExpr::Temporal {
+            operator: TemporalOperator::BoundedEventually(bound),
+            body: expr,
+        })
     }
 
     fn check_verb(&self) -> bool {

--- a/crates/logicaffeine_language/src/parser/quantifier.rs
+++ b/crates/logicaffeine_language/src/parser/quantifier.rs
@@ -121,6 +121,102 @@ impl<'a, 'ctx, 'int> QuantifierParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int
             self.in_negative_quantifier = true;
         }
 
+        // "At most one of X, Y, and Z is P" — counting quantifier with explicit list
+        if matches!(quantifier_token, TokenType::AtMost(_) | TokenType::AtLeast(_) | TokenType::Cardinal(_))
+            && self.check_preposition_is("of")
+        {
+            self.advance(); // consume "of"
+
+            // Parse comma-separated list of identifiers: "grant0, grant1, and grant2"
+            let mut signal_names: Vec<Symbol> = Vec::new();
+            loop {
+                let name = self.consume_content_word()?;
+                signal_names.push(name);
+
+                if self.check(&TokenType::Comma) {
+                    self.advance(); // consume ","
+                    // Skip optional "and" after comma: "X, Y, and Z"
+                    if self.check(&TokenType::And) {
+                        self.advance();
+                    }
+                } else if self.check(&TokenType::And) {
+                    self.advance(); // consume "and" (two-element: "X and Y")
+                } else {
+                    break;
+                }
+            }
+
+            // Now parse the predicate: "is asserted", "is valid", etc.
+            // In hardware context, the predicate is implicit — what matters
+            // is each signal name being high/low. Consume but don't use.
+            let mut is_negated = false;
+            if self.check(&TokenType::Is) || self.check(&TokenType::Are) {
+                self.advance(); // consume copula
+                is_negated = self.check(&TokenType::Not);
+                if is_negated {
+                    self.advance();
+                }
+                // Consume the predicate adjective/verb (e.g., "asserted", "valid")
+                let _ = self.consume_content_word();
+                // Consume optional trailing "at any time"
+                while self.check_preposition_is("at") {
+                    self.advance();
+                    if self.check(&TokenType::Any) {
+                        self.advance();
+                    }
+                    if self.check_content_word() {
+                        self.advance();
+                    }
+                }
+            }
+
+            // Build the body: each signal as an Atom, joined by OR
+            // SVA synthesis maps Atom(sig) → signal name directly
+            let mut signal_exprs: Vec<&'a LogicExpr<'a>> = Vec::new();
+            for &sig in &signal_names {
+                let atom: &'a LogicExpr<'a> = self.ctx.exprs.alloc(LogicExpr::Atom(sig));
+                let sig_expr = if is_negated {
+                    self.ctx.exprs.alloc(LogicExpr::UnaryOp {
+                        op: TokenType::Not,
+                        operand: atom,
+                    })
+                } else {
+                    atom
+                };
+                signal_exprs.push(sig_expr);
+            }
+
+            let body = if signal_exprs.len() == 1 {
+                signal_exprs[0]
+            } else {
+                let mut combined = signal_exprs[0];
+                for &expr in &signal_exprs[1..] {
+                    combined = self.ctx.exprs.alloc(LogicExpr::BinaryOp {
+                        left: combined,
+                        op: TokenType::Or,
+                        right: expr,
+                    });
+                }
+                combined
+            };
+
+            let kind = match quantifier_token {
+                TokenType::AtMost(n) => QuantifierKind::AtMost(n),
+                TokenType::AtLeast(n) => QuantifierKind::AtLeast(n),
+                TokenType::Cardinal(n) => QuantifierKind::Cardinal(n),
+                _ => unreachable!(),
+            };
+
+            self.in_negative_quantifier = was_in_negative_quantifier;
+
+            return Ok(self.ctx.exprs.alloc(LogicExpr::Quantifier {
+                kind,
+                variable: var_name,
+                body,
+                island_id: self.current_island,
+            }));
+        }
+
         let subject_pred = self.parse_restriction(var_name)?;
 
         if self.check_modal() {

--- a/crates/logicaffeine_language/src/parser/verb.rs
+++ b/crates/logicaffeine_language/src/parser/verb.rs
@@ -1191,6 +1191,12 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
             let unknown = self.interner.intern("?");
             let mut pp_predicates: Vec<&'a LogicExpr<'a>> = Vec::new();
             while self.check_preposition() || self.check_to() {
+                // "within N cycles" is a temporal bound, not a PP — leave for try_wrap_bounded_delay
+                if self.check_preposition_is("within") && self.current + 1 < self.tokens.len()
+                    && matches!(self.tokens[self.current + 1].kind, TokenType::Cardinal(_) | TokenType::Number(_))
+                {
+                    break;
+                }
                 let prep_token = self.advance().clone();
                 let prep_name = if let TokenType::Preposition(sym) = prep_token.kind {
                     sym
@@ -1411,11 +1417,13 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
 
 impl<'a, 'ctx, 'int> LogicVerbParsing<'a, 'ctx, 'int> for Parser<'a, 'ctx, 'int> {
     fn parse_predicate_with_subject(&mut self, subject_symbol: Symbol) -> ParseResult<&'a LogicExpr<'a>> {
-        self.parse_predicate_impl(subject_symbol, false)
+        let result = self.parse_predicate_impl(subject_symbol, false)?;
+        Ok(self.try_wrap_bounded_delay(result))
     }
 
     fn parse_predicate_with_subject_as_var(&mut self, subject_symbol: Symbol) -> ParseResult<&'a LogicExpr<'a>> {
-        self.parse_predicate_impl(subject_symbol, true)
+        let result = self.parse_predicate_impl(subject_symbol, true)?;
+        Ok(self.try_wrap_bounded_delay(result))
     }
 
     fn try_parse_plural_subject(

--- a/crates/logicaffeine_language/src/parser/verb.rs
+++ b/crates/logicaffeine_language/src/parser/verb.rs
@@ -567,6 +567,24 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                 self.advance(); // consume "not"
             }
 
+            // Check for temporal adverbs after copula: "is eventually Y", "is always Y", "is never Y"
+            let mut copula_temporal: Option<super::CopulaTemporal> = None;
+            if !is_negated {
+                if self.check(&TokenType::Never) {
+                    self.advance();
+                    copula_temporal = Some(super::CopulaTemporal::Never);
+                } else if let TokenType::Adverb(sym) | TokenType::ScopalAdverb(sym) | TokenType::TemporalAdverb(sym) = &self.peek().kind {
+                    let resolved = self.interner.resolve(*sym).to_string();
+                    if resolved == "Always" || resolved == "always" {
+                        self.advance();
+                        copula_temporal = Some(super::CopulaTemporal::Always);
+                    } else if resolved == "Eventually" || resolved == "eventually" {
+                        self.advance();
+                        copula_temporal = Some(super::CopulaTemporal::Eventually);
+                    }
+                }
+            }
+
             if self.check_verb() {
                 let (verb, _verb_time, verb_aspect, verb_class) = self.consume_verb_with_metadata();
 
@@ -608,14 +626,42 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                     with_aspect
                 };
 
-                return Ok(if is_negated {
+                let with_neg = if is_negated {
                     self.ctx.exprs.alloc(LogicExpr::UnaryOp {
                         op: TokenType::Not,
                         operand: with_time,
                     })
                 } else {
                     with_time
-                });
+                };
+
+                let result = match copula_temporal {
+                    Some(super::CopulaTemporal::Always) => {
+                        self.ctx.exprs.alloc(LogicExpr::Temporal {
+                            operator: TemporalOperator::Always,
+                            body: with_neg,
+                        })
+                    }
+                    Some(super::CopulaTemporal::Never) => {
+                        let negated = self.ctx.exprs.alloc(LogicExpr::UnaryOp {
+                            op: TokenType::Not,
+                            operand: with_time,
+                        });
+                        self.ctx.exprs.alloc(LogicExpr::Temporal {
+                            operator: TemporalOperator::Always,
+                            body: negated,
+                        })
+                    }
+                    Some(super::CopulaTemporal::Eventually) => {
+                        self.ctx.exprs.alloc(LogicExpr::Temporal {
+                            operator: TemporalOperator::Eventually,
+                            body: with_neg,
+                        })
+                    }
+                    None => with_neg,
+                };
+
+                return Ok(result);
             }
 
             let predicate = self.consume_content_word()?;
@@ -634,14 +680,42 @@ impl<'a, 'ctx, 'int> Parser<'a, 'ctx, 'int> {
                 base_pred
             };
 
-            return Ok(if is_negated {
+            let with_neg = if is_negated {
                 self.ctx.exprs.alloc(LogicExpr::UnaryOp {
                     op: TokenType::Not,
                     operand: with_time,
                 })
             } else {
                 with_time
-            });
+            };
+
+            let result = match copula_temporal {
+                Some(super::CopulaTemporal::Always) => {
+                    self.ctx.exprs.alloc(LogicExpr::Temporal {
+                        operator: TemporalOperator::Always,
+                        body: with_neg,
+                    })
+                }
+                Some(super::CopulaTemporal::Never) => {
+                    let negated = self.ctx.exprs.alloc(LogicExpr::UnaryOp {
+                        op: TokenType::Not,
+                        operand: with_time,
+                    });
+                    self.ctx.exprs.alloc(LogicExpr::Temporal {
+                        operator: TemporalOperator::Always,
+                        body: negated,
+                    })
+                }
+                Some(super::CopulaTemporal::Eventually) => {
+                    self.ctx.exprs.alloc(LogicExpr::Temporal {
+                        operator: TemporalOperator::Eventually,
+                        body: with_neg,
+                    })
+                }
+                None => with_neg,
+            };
+
+            return Ok(result);
         }
 
         // Handle "did it" - when Auxiliary(Past) is used as a transitive verb (past of "do")

--- a/crates/logicaffeine_language/src/proof_convert.rs
+++ b/crates/logicaffeine_language/src/proof_convert.rs
@@ -145,7 +145,8 @@ pub fn logic_expr_to_proof_expr<'a>(expr: &LogicExpr<'a>, interner: &Interner) -
                 TemporalOperator::Past => "Past",
                 TemporalOperator::Future => "Future",
                 TemporalOperator::Always => "Always",
-                TemporalOperator::Eventually => "Eventually",
+                TemporalOperator::Eventually
+                | TemporalOperator::BoundedEventually(_) => "Eventually",
                 TemporalOperator::Next => "Next",
             };
             ProofExpr::Temporal {

--- a/crates/logicaffeine_language/src/semantics/knowledge_graph.rs
+++ b/crates/logicaffeine_language/src/semantics/knowledge_graph.rs
@@ -467,6 +467,25 @@ pub fn extract_from_kripke_ast<'a>(
                      in_safety, in_liveness || is_temporal_world, position, impl_depth);
             }
 
+            // Counting quantifiers (AtMost, AtLeast, Cardinal, etc.) — recurse into body
+            LogicExpr::Quantifier { body, .. } => {
+                walk(body, interner, kg, seen, antecedent, consequent, pred_names,
+                     in_safety, in_liveness, position, impl_depth);
+            }
+
+            // Atom: bare symbol — treat as signal name
+            LogicExpr::Atom(sym) => {
+                let name = interner.resolve(*sym).to_string();
+                if !name.is_empty() && name.len() > 1 {
+                    seen.insert(name.clone());
+                    match position {
+                        Position::Antecedent => { antecedent.insert(name); }
+                        Position::Consequent => { consequent.insert(name); }
+                        Position::Neutral => {}
+                    }
+                }
+            }
+
             // Binary connectives: walk both sides
             LogicExpr::BinaryOp { left, right, op } => {
                 // TokenType::If = user-written conditional (provenance tag).

--- a/crates/logicaffeine_language/src/semantics/kripke.rs
+++ b/crates/logicaffeine_language/src/semantics/kripke.rs
@@ -174,6 +174,14 @@ fn lower_expr<'a>(
                         "Reachable_Temporal", false,
                     )
                 }
+                TemporalOperator::BoundedEventually(n) => {
+                    // F≤n(φ) — preserve bound for SVA synthesis (##[0:n])
+                    let lowered_body = lower_expr(body, ctx, expr_arena, term_arena, interner);
+                    expr_arena.alloc(LogicExpr::Temporal {
+                        operator: TemporalOperator::BoundedEventually(*n),
+                        body: lowered_body,
+                    })
+                }
                 TemporalOperator::Next => {
                     // X(φ) → ∀w'(Next_Temporal(w, w') → φ(w'))
                     ctx.tick_clock();

--- a/crates/logicaffeine_tests/Cargo.toml
+++ b/crates/logicaffeine_tests/Cargo.toml
@@ -32,3 +32,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 bincode = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+csv = "1"

--- a/crates/logicaffeine_tests/tests/phase_hw_benchmark.rs
+++ b/crates/logicaffeine_tests/tests/phase_hw_benchmark.rs
@@ -1,0 +1,900 @@
+//! Hardware Benchmark: Broad FOL→SVA Synthesis Probe
+//!
+//! A discovery-oriented benchmark that runs ~105 handwritten hardware property
+//! sentences + 379 FVEval (NVIDIA) NL-to-SVA specs through
+//! `synthesize_sva_from_spec()` and reports results.
+//!
+//! Two layers:
+//! - Layer 1 (probe): table-driven, non-failing — discovers gaps
+//! - Layer 2 (regression): individual `#[test]` fns for confirmed-passing specs
+
+use logicaffeine_compile::codegen_sva::fol_to_sva::{synthesize_sva_from_spec, SynthesizedSva};
+use logicaffeine_compile::codegen_sva::sva_model::parse_sva;
+use std::path::Path;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DATA STRUCTURES
+// ═══════════════════════════════════════════════════════════════════════════
+
+struct HwSpec {
+    spec: &'static str,
+    tags: &'static [&'static str],
+}
+
+/// Check if SVA body is degenerate (vacuous or trivially broken)
+fn is_degenerate(body: &str) -> bool {
+    let trimmed = body.trim();
+    trimmed == "0"
+        || trimmed == "1"
+        || trimmed == "0 |-> 0"
+        || trimmed == "1 |-> 1"
+        || trimmed.starts_with("0 |->")
+        || trimmed.ends_with("|-> 0")
+}
+
+/// Synthesize and assert: parse OK + non-degenerate + parseable SVA
+fn synth_hw(spec: &str) -> SynthesizedSva {
+    let r = synthesize_sva_from_spec(spec, "clk")
+        .unwrap_or_else(|e| panic!("Parse failed for '{}': {}", spec, e));
+    assert!(!is_degenerate(&r.body), "Degenerate body for '{}': '{}'", spec, r.body);
+    let parse = parse_sva(&r.body);
+    assert!(parse.is_ok(), "Unparseable SVA for '{}': body='{}' err={:?}", spec, r.body, parse.err());
+    r
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE CORPUS (~105 unique hardware specs)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const CORPUS: &[HwSpec] = &[
+
+    // ── Safety Invariants ──
+    HwSpec { spec: "Always, every signal is valid.", tags: &["safety", "basic"] },
+    HwSpec { spec: "Always, every signal is ready.", tags: &["safety", "basic"] },
+    HwSpec { spec: "Always, every wire is high.", tags: &["safety", "basic"] },
+    HwSpec { spec: "Always, every register is valid.", tags: &["safety", "basic"] },
+    HwSpec { spec: "The signal is always valid.", tags: &["safety", "copula_temporal"] },
+    HwSpec { spec: "The clock is never low.", tags: &["safety", "copula_temporal", "negation"] },
+
+    // ── Conditional Safety ──
+    HwSpec { spec: "Always, if every request is valid then every grant is valid.", tags: &["conditional", "handshake"] },
+    HwSpec { spec: "Always, if every valid holds then every ready holds.", tags: &["conditional", "handshake"] },
+    HwSpec { spec: "Always, if every request holds then every acknowledgment holds.", tags: &["conditional", "handshake"] },
+    HwSpec { spec: "Always, if every request holds, then eventually, every response holds.", tags: &["conditional", "liveness", "handshake"] },
+    HwSpec { spec: "If the wire is high, the latch is full.", tags: &["conditional"] },
+
+    // ── Conditional + Stability ──
+    HwSpec { spec: "If valid is asserted and ready is not asserted, data remains stable.", tags: &["conditional", "stability", "known_gap"] },
+    HwSpec { spec: "If enable is low, the register holds its value.", tags: &["conditional", "stability", "known_gap"] },
+    HwSpec { spec: "If enable is low, the output remains valid.", tags: &["conditional", "stability", "known_gap"] },
+
+    // ── Conditional + Temporal Delay ──
+    HwSpec { spec: "If request is asserted, acknowledge is asserted within 2 cycles.", tags: &["conditional", "delay", "known_gap"] },
+    HwSpec { spec: "If request is deasserted, grant is deasserted within 1 cycle.", tags: &["conditional", "delay", "known_gap"] },
+    HwSpec { spec: "If reset is asserted, valid is low within 1 cycle.", tags: &["conditional", "delay", "reset", "known_gap"] },
+    HwSpec { spec: "If reset is deasserted, ready is asserted within 3 cycles.", tags: &["conditional", "delay", "reset", "known_gap"] },
+    HwSpec { spec: "If start is asserted, done is asserted in the next cycle.", tags: &["conditional", "delay", "known_gap"] },
+    HwSpec { spec: "If an error is detected, the interrupt is raised within 1 cycle.", tags: &["conditional", "delay", "error", "known_gap"] },
+    HwSpec { spec: "If start bit is detected, stop bit follows within 10 cycles.", tags: &["conditional", "delay", "serial", "known_gap"] },
+
+    // ── FIFO Properties ──
+    HwSpec { spec: "If the FIFO is full, write is not asserted.", tags: &["conditional", "fifo", "known_gap"] },
+    HwSpec { spec: "If the FIFO is empty, read is not asserted.", tags: &["conditional", "fifo", "known_gap"] },
+    HwSpec { spec: "If write is asserted and full is low, the write pointer advances.", tags: &["conditional", "fifo", "known_gap"] },
+    HwSpec { spec: "If read is asserted and empty is low, the read pointer advances.", tags: &["conditional", "fifo", "known_gap"] },
+
+    // ── Reset Properties ──
+    HwSpec { spec: "After reset, the counter is zero.", tags: &["reset", "after", "known_gap"] },
+    HwSpec { spec: "After reset is deasserted, the signal is valid.", tags: &["reset", "after", "known_gap"] },
+    HwSpec { spec: "The output is never high while reset is asserted.", tags: &["reset", "while", "negation", "known_gap"] },
+
+    // ── Error Handling ──
+    HwSpec { spec: "If parity error is detected, the error flag is asserted.", tags: &["conditional", "error", "known_gap"] },
+    HwSpec { spec: "If overflow is detected, the status bit is set.", tags: &["conditional", "error", "known_gap"] },
+
+    // ── Mutex / Mutual Exclusion ──
+    HwSpec { spec: "Always, not both every request is valid and every grant is valid.", tags: &["mutex", "negation"] },
+    HwSpec { spec: "Grant0 and Grant1 are not both asserted.", tags: &["mutex", "known_gap"] },
+    HwSpec { spec: "Read and write are not both asserted.", tags: &["mutex", "known_gap"] },
+    HwSpec { spec: "At most one signal is valid.", tags: &["mutex", "counting"] },
+    HwSpec { spec: "At most one grant is valid.", tags: &["mutex", "counting"] },
+    HwSpec { spec: "At most one of grant0, grant1, and grant2 is asserted.", tags: &["mutex", "counting", "known_gap"] },
+    HwSpec { spec: "At most one request is granted at any time.", tags: &["mutex", "counting", "known_gap"] },
+
+    // ── Liveness ──
+    HwSpec { spec: "Eventually, every signal is valid.", tags: &["liveness"] },
+    HwSpec { spec: "Eventually, every done is valid.", tags: &["liveness"] },
+    HwSpec { spec: "Always, eventually every signal is ready.", tags: &["liveness", "nested_temporal"] },
+
+    // ── Next-Cycle ──
+    HwSpec { spec: "Next, every signal is valid.", tags: &["nexttime"] },
+    HwSpec { spec: "Next, every grant is valid.", tags: &["nexttime"] },
+
+    // ── Temporal Binary ──
+    HwSpec { spec: "Every request holds until every grant holds.", tags: &["until"] },
+    HwSpec { spec: "Every signal is valid until every done is valid.", tags: &["until"] },
+    HwSpec { spec: "If valid is asserted, it remains asserted until ready is asserted.", tags: &["until", "stability", "known_gap"] },
+
+    // ── Modal / Obligation ──
+    HwSpec { spec: "The receiver shall acknowledge every request.", tags: &["modal"] },
+    HwSpec { spec: "The transmitter shall not send data while idle.", tags: &["modal", "while", "negation", "known_gap"] },
+    HwSpec { spec: "Every request must be granted.", tags: &["modal", "passive"] },
+
+    // ── While / Duration ──
+    HwSpec { spec: "While valid is asserted and ready is not asserted, data is stable.", tags: &["while", "stability", "known_gap"] },
+
+    // ── After / Sequencing ──
+    HwSpec { spec: "After request, grant follows within 3 cycles.", tags: &["after", "delay", "known_gap"] },
+
+    // ── Conjunction / Disjunction ──
+    HwSpec { spec: "Always, every request is valid and every grant is valid.", tags: &["conjunction"] },
+    HwSpec { spec: "Always, every request is valid or every grant is valid.", tags: &["disjunction"] },
+    HwSpec { spec: "Always, every request is valid and every grant is valid and every signal is ready.", tags: &["conjunction", "three_way"] },
+
+    // ── Negation ──
+    HwSpec { spec: "Always, not every signal is valid.", tags: &["negation"] },
+    HwSpec { spec: "If request is not asserted, acknowledge is not asserted.", tags: &["negation", "conditional", "known_gap"] },
+
+    // ── Counting / Cardinality ──
+    HwSpec { spec: "At most two signals are valid.", tags: &["counting"] },
+    HwSpec { spec: "At least one signal is valid.", tags: &["counting"] },
+    HwSpec { spec: "At least two signals are valid.", tags: &["counting"] },
+
+    // ── Passive Voice ──
+    HwSpec { spec: "The signal must be acknowledged.", tags: &["passive", "modal"] },
+    HwSpec { spec: "The data is transferred when valid and ready are both high.", tags: &["passive", "conditional", "known_gap"] },
+
+    // ── NeoEvent / Action ──
+    HwSpec { spec: "The arbiter grants the request.", tags: &["action", "neoevent"] },
+    HwSpec { spec: "The controller enables the latch.", tags: &["action", "neoevent"] },
+    HwSpec { spec: "The bus acknowledges the request.", tags: &["action", "neoevent"] },
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ASSERTIONFORGE-INSPIRED: REAL SoC/PROTOCOL PROPERTIES
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // ── Reset Propagation ──
+    HwSpec { spec: "If reset_n is low, puc_rst is high in the next cycle.", tags: &["reset", "nexttime", "assertionforge", "rtl_names"] },
+    HwSpec { spec: "If reset_n is low, every register is invalid.", tags: &["reset", "conditional", "assertionforge"] },
+
+    // ── IRQ Consistency ──
+    HwSpec { spec: "If irq is zero, irq_ack is zero.", tags: &["irq", "conditional", "assertionforge", "rtl_names"] },
+    HwSpec { spec: "If irq is not asserted, irq_ack is not asserted.", tags: &["irq", "conditional", "assertionforge", "rtl_names"] },
+    HwSpec { spec: "If irq is asserted, irq_ack is asserted within 3 cycles.", tags: &["irq", "delay", "assertionforge", "rtl_names", "known_gap"] },
+
+    // ── DMA Safety ──
+    HwSpec { spec: "If dma_en and dma_we are asserted, dma_din is never unknown.", tags: &["dma", "safety", "assertionforge", "rtl_names", "stretch"] },
+    HwSpec { spec: "If dma_en is asserted, dma_addr is valid.", tags: &["dma", "conditional", "assertionforge", "rtl_names"] },
+    HwSpec { spec: "If dma_en is not asserted, dma_we is not asserted.", tags: &["dma", "conditional", "assertionforge", "rtl_names"] },
+
+    // ── Clock/Domain Checks ──
+    HwSpec { spec: "If smclk_en and cpu_en are asserted, smclk is never unknown.", tags: &["clock", "safety", "assertionforge", "rtl_names", "stretch"] },
+    HwSpec { spec: "If clk_en is low, the register holds its value.", tags: &["clock", "stability", "assertionforge", "rtl_names", "known_gap"] },
+
+    // ── Wakeup / Power ──
+    HwSpec { spec: "If dco_enable is low and cpu_en is high, dco_wkup is asserted.", tags: &["power", "conditional", "assertionforge", "rtl_names", "stretch"] },
+    HwSpec { spec: "If wakeup is asserted, cpu_en is asserted within 2 cycles.", tags: &["power", "delay", "assertionforge", "rtl_names", "known_gap"] },
+
+    // ── APB Bus Timing ──
+    HwSpec { spec: "If PADDR is valid, PWRITE is stable until PENABLE is asserted.", tags: &["apb", "stability", "until", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If PSEL and PENABLE are asserted, PREADY follows within 1 cycle.", tags: &["apb", "delay", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If PSEL is not asserted, PENABLE is not asserted.", tags: &["apb", "conditional", "assertionforge"] },
+    HwSpec { spec: "If PENABLE is asserted, PSEL is asserted.", tags: &["apb", "conditional", "assertionforge"] },
+
+    // ── UART Transmit Control ──
+    HwSpec { spec: "If tx_busy is low and new_tx_data is asserted, tx_busy is asserted in the next cycle.", tags: &["uart", "nexttime", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If tx_busy is high, new_tx_data is not asserted.", tags: &["uart", "conditional", "assertionforge"] },
+    HwSpec { spec: "If rx_valid is asserted, rx_data is valid.", tags: &["uart", "conditional", "assertionforge"] },
+
+    // ── AXI Protocol ──
+    HwSpec { spec: "If AWVALID is asserted, AWVALID remains asserted until AWREADY is asserted.", tags: &["axi", "until", "stability", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If ARVALID is asserted, ARADDR is valid.", tags: &["axi", "conditional", "assertionforge"] },
+    HwSpec { spec: "If WVALID and WREADY are asserted, BVALID is asserted within 3 cycles.", tags: &["axi", "delay", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If RVALID is asserted, RDATA is valid.", tags: &["axi", "conditional", "assertionforge"] },
+    HwSpec { spec: "If BVALID is asserted, BRESP is valid.", tags: &["axi", "conditional", "assertionforge"] },
+
+    // ── SPI Interface ──
+    HwSpec { spec: "If spi_cs is low, spi_clk is valid.", tags: &["spi", "conditional", "assertionforge"] },
+    HwSpec { spec: "If spi_cs is high, spi_mosi is not asserted.", tags: &["spi", "conditional", "assertionforge"] },
+    HwSpec { spec: "If spi_cs is low, spi_miso is valid within 1 cycle.", tags: &["spi", "delay", "assertionforge", "known_gap"] },
+
+    // ── Arbiter Fairness ──
+    HwSpec { spec: "If request is asserted, grant is eventually asserted.", tags: &["arbiter", "liveness", "assertionforge", "known_gap"] },
+    HwSpec { spec: "At most one grant is asserted at any time.", tags: &["arbiter", "mutex", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If grant is asserted and request is not asserted, grant is not asserted in the next cycle.", tags: &["arbiter", "nexttime", "assertionforge", "known_gap"] },
+
+    // ── Pipeline Hazards ──
+    HwSpec { spec: "If stall is asserted, the register holds its value.", tags: &["pipeline", "stability", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If flush is asserted, valid is low in the next cycle.", tags: &["pipeline", "nexttime", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If valid is asserted and stall is not asserted, done is asserted in the next cycle.", tags: &["pipeline", "nexttime", "assertionforge", "known_gap"] },
+
+    // ── Memory Interface ──
+    HwSpec { spec: "If mem_req is asserted, mem_ack is asserted within 4 cycles.", tags: &["memory", "delay", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If mem_we is asserted, mem_addr is valid.", tags: &["memory", "conditional", "assertionforge"] },
+    HwSpec { spec: "Read and write are not both asserted.", tags: &["memory", "mutex"] },
+
+    // ── Counter / Timer ──
+    HwSpec { spec: "If enable is high and the counter is full, the counter is zero in the next cycle.", tags: &["counter", "nexttime", "assertionforge", "known_gap"] },
+    HwSpec { spec: "If enable is low, the counter holds its value.", tags: &["counter", "stability", "assertionforge", "known_gap"] },
+
+    // ── CDC (Clock Domain Crossing) ──
+    HwSpec { spec: "If sync_req is asserted, sync_ack is asserted within 3 cycles.", tags: &["cdc", "delay", "assertionforge", "known_gap"] },
+];
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LAYER 1: PROBE HARNESS (discovery mode — never hard-fails)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn benchmark_corpus_probe() {
+    let mut pass = 0u32;
+    let mut parse_fail = 0u32;
+    let mut degenerate = 0u32;
+    let mut unparseable_sva = 0u32;
+    let mut suspicious = 0u32;
+
+    for case in CORPUS {
+        let result = synthesize_sva_from_spec(case.spec, "clk");
+        match result {
+            Err(e) => {
+                parse_fail += 1;
+                eprintln!("PARSE-FAIL [{}]: {} — {}", case.tags.join(","), case.spec, e);
+            }
+            Ok(r) if is_degenerate(&r.body) => {
+                degenerate += 1;
+                eprintln!("DEGENERATE [{}]: {} → {}", case.tags.join(","), case.spec, r.body);
+            }
+            Ok(r) => {
+                if parse_sva(&r.body).is_err() {
+                    unparseable_sva += 1;
+                    eprintln!("BAD-SVA [{}]: {} → {}", case.tags.join(","), case.spec, r.body);
+                } else if r.signals.is_empty() {
+                    suspicious += 1;
+                    eprintln!("SUSPICIOUS [{}]: {} → {} (no signals)", case.tags.join(","), case.spec, r.body);
+                } else {
+                    pass += 1;
+                }
+            }
+        }
+    }
+    let total = CORPUS.len();
+    eprintln!("\n=== HW BENCHMARK ===");
+    eprintln!("  total:         {total}");
+    eprintln!("  pass:          {pass}/{total}");
+    eprintln!("  parse-fail:    {parse_fail}");
+    eprintln!("  degenerate:    {degenerate}");
+    eprintln!("  bad-sva:       {unparseable_sva}");
+    eprintln!("  suspicious:    {suspicious}");
+    // Don't assert on pass count — this is discovery, not regression
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LAYER 1b: FVEval PROBE (NVIDIA NL2SVA benchmark — discovery mode)
+// Source: https://github.com/NVlabs/FVEval (arXiv:2410.23299)
+// 300 machine-generated + 79 human-written specs from real designs
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Load prompts from an FVEval CSV file. Returns (prompt, task_id) pairs.
+fn load_fveval_csv(path: &Path) -> Vec<(String, String)> {
+    let mut rdr = csv::Reader::from_path(path)
+        .unwrap_or_else(|e| panic!("Failed to open {}: {}", path.display(), e));
+    let mut specs = Vec::new();
+    for result in rdr.records() {
+        let record = result.expect("bad CSV record");
+        let task_id = record.get(1).unwrap_or("?").to_string();
+        let prompt = record.get(2).unwrap_or("").to_string();
+        if !prompt.is_empty() {
+            specs.push((prompt, task_id));
+        }
+    }
+    specs
+}
+
+/// Run the probe on a set of (prompt, label) pairs and print summary.
+/// Returns (pass, parse_fail, degenerate, bad_sva, suspicious, total).
+fn run_fveval_probe(specs: &[(String, String)], label: &str) -> (u32, u32, u32, u32, u32, usize) {
+    let mut pass = 0u32;
+    let mut parse_fail = 0u32;
+    let mut degenerate = 0u32;
+    let mut bad_sva = 0u32;
+    let mut suspicious = 0u32;
+
+    for (prompt, task_id) in specs {
+        let result = synthesize_sva_from_spec(prompt, "clk");
+        match result {
+            Err(e) => {
+                parse_fail += 1;
+                eprintln!("FVEVAL-PARSE-FAIL [{}:{}]: {} — {}", label, task_id, &prompt[..prompt.len().min(80)], e);
+            }
+            Ok(r) if is_degenerate(&r.body) => {
+                degenerate += 1;
+                eprintln!("FVEVAL-DEGENERATE [{}:{}]: {} → {}", label, task_id, &prompt[..prompt.len().min(80)], r.body);
+            }
+            Ok(r) => {
+                if parse_sva(&r.body).is_err() {
+                    bad_sva += 1;
+                    eprintln!("FVEVAL-BAD-SVA [{}:{}]: {} → {}", label, task_id, &prompt[..prompt.len().min(80)], r.body);
+                } else if r.signals.is_empty() {
+                    suspicious += 1;
+                } else {
+                    pass += 1;
+                }
+            }
+        }
+    }
+    let total = specs.len();
+    eprintln!("\n=== FVEVAL {} ===", label.to_uppercase());
+    eprintln!("  total:         {total}");
+    eprintln!("  pass:          {pass}/{total}");
+    eprintln!("  parse-fail:    {parse_fail}");
+    eprintln!("  degenerate:    {degenerate}");
+    eprintln!("  bad-sva:       {bad_sva}");
+    eprintln!("  suspicious:    {suspicious}");
+
+    (pass, parse_fail, degenerate, bad_sva, suspicious, total)
+}
+
+#[test]
+fn fveval_machine_probe() {
+    let csv_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../FVEval/data_nl2sva/data/nl2sva_machine.csv");
+    if !csv_path.exists() {
+        eprintln!("SKIP: FVEval machine CSV not found at {}", csv_path.display());
+        return;
+    }
+    let specs = load_fveval_csv(&csv_path);
+    assert!(!specs.is_empty(), "Machine CSV loaded 0 specs");
+    let (pass, _pf, _deg, _bad, _sus, total) = run_fveval_probe(&specs, "machine");
+    eprintln!("  pass-rate:     {:.1}%", pass as f64 / total as f64 * 100.0);
+}
+
+#[test]
+fn fveval_human_probe() {
+    let csv_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../FVEval/data_nl2sva/data/nl2sva_human.csv");
+    if !csv_path.exists() {
+        eprintln!("SKIP: FVEval human CSV not found at {}", csv_path.display());
+        return;
+    }
+    let specs = load_fveval_csv(&csv_path);
+    assert!(!specs.is_empty(), "Human CSV loaded 0 specs");
+    let (pass, _pf, _deg, _bad, _sus, total) = run_fveval_probe(&specs, "human");
+    eprintln!("  pass-rate:     {:.1}%", pass as f64 / total as f64 * 100.0);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SEPARATE TESTS: ERROR HANDLING (not in corpus)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn error_empty_spec() {
+    let result = synthesize_sva_from_spec("", "clk");
+    assert!(result.is_err(), "Empty spec should return error");
+}
+
+#[test]
+fn error_gibberish_does_not_panic() {
+    let _ = synthesize_sva_from_spec("asdf qwerty zxcv", "clk");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SEPARATE TESTS: CLOCK VARIATIONS (not in corpus)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn clock_variation_sys_clk() {
+    let r = synthesize_sva_from_spec("Always, every signal is valid.", "sys_clk").unwrap();
+    assert!(r.sva_text.contains("sys_clk"),
+        "Should contain sys_clk. Got: {}", r.sva_text);
+}
+
+#[test]
+fn clock_variation_pclk() {
+    let r = synthesize_sva_from_spec("Always, every signal is valid.", "pclk").unwrap();
+    assert!(r.sva_text.contains("pclk"),
+        "Should contain pclk. Got: {}", r.sva_text);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// LAYER 2: REGRESSION TESTS (must-pass, promoted from probe results)
+// Promoted after benchmark_corpus_probe confirmed these pass cleanly.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── Safety Invariants ──
+
+#[test]
+fn reg_safety_always_signal_valid() {
+    let r = synth_hw("Always, every signal is valid.");
+    assert!(r.sva_text.contains("assert property"));
+}
+
+#[test]
+fn reg_safety_always_register_valid() {
+    synth_hw("Always, every register is valid.");
+}
+
+#[test]
+fn reg_safety_always_wire_high() {
+    synth_hw("Always, every wire is high.");
+}
+
+#[test]
+fn reg_safety_copula_signal_always_valid() {
+    let r = synth_hw("The signal is always valid.");
+    assert!(r.sva_text.contains("assert property") || r.sva_text.contains("@(posedge"));
+}
+
+#[test]
+fn reg_safety_copula_clock_never_low() {
+    let r = synth_hw("The clock is never low.");
+    assert!(r.body.contains("!") || r.body.contains("not") || r.body.contains("~"),
+        "Negation expected in body. Got: {}", r.body);
+}
+
+// ── Conditional Safety / Handshake ──
+
+#[test]
+fn reg_cond_request_grant() {
+    let r = synth_hw("Always, if every request is valid then every grant is valid.");
+    assert!(r.body.contains("|->") || r.body.contains("|=>"),
+        "Should produce implication. Got: {}", r.body);
+}
+
+#[test]
+fn reg_cond_valid_ready() {
+    let r = synth_hw("Always, if every valid holds then every ready holds.");
+    assert!(r.signals.len() >= 2, "Should extract >= 2 signals. Got: {:?}", r.signals);
+}
+
+#[test]
+fn reg_cond_request_ack() {
+    synth_hw("Always, if every request holds then every acknowledgment holds.");
+}
+
+#[test]
+fn reg_cond_liveness_request_response() {
+    let r = synth_hw("Always, if every request holds, then eventually, every response holds.");
+    assert!(r.body.contains("s_eventually") || r.sva_text.contains("cover"),
+        "Should contain s_eventually. Got body: {}", r.body);
+}
+
+#[test]
+fn reg_cond_wire_latch() {
+    synth_hw("If the wire is high, the latch is full.");
+}
+
+// ── Conditional + Stability ──
+
+#[test]
+fn reg_stability_valid_ready_data() {
+    synth_hw("If valid is asserted and ready is not asserted, data remains stable.");
+}
+
+#[test]
+fn reg_stability_enable_register() {
+    synth_hw("If enable is low, the register holds its value.");
+}
+
+#[test]
+fn reg_stability_enable_output() {
+    synth_hw("If enable is low, the output remains valid.");
+}
+
+// ── Conditional + Temporal Delay ──
+
+#[test]
+fn reg_delay_request_ack_2_cycles() {
+    synth_hw("If request is asserted, acknowledge is asserted within 2 cycles.");
+}
+
+#[test]
+fn reg_delay_request_grant_deasserted() {
+    synth_hw("If request is deasserted, grant is deasserted within 1 cycle.");
+}
+
+#[test]
+fn reg_delay_reset_valid_low() {
+    synth_hw("If reset is asserted, valid is low within 1 cycle.");
+}
+
+#[test]
+fn reg_delay_start_done_next() {
+    synth_hw("If start is asserted, done is asserted in the next cycle.");
+}
+
+#[test]
+fn reg_delay_error_interrupt() {
+    synth_hw("If an error is detected, the interrupt is raised within 1 cycle.");
+}
+
+#[test]
+fn reg_delay_start_stop_serial() {
+    synth_hw("If start bit is detected, stop bit follows within 10 cycles.");
+}
+
+// ── FIFO ──
+
+#[test]
+fn reg_fifo_full_no_write() {
+    synth_hw("If the FIFO is full, write is not asserted.");
+}
+
+#[test]
+fn reg_fifo_empty_no_read() {
+    synth_hw("If the FIFO is empty, read is not asserted.");
+}
+
+#[test]
+fn reg_fifo_write_pointer_advance() {
+    synth_hw("If write is asserted and full is low, the write pointer advances.");
+}
+
+#[test]
+fn reg_fifo_read_pointer_advance() {
+    synth_hw("If read is asserted and empty is low, the read pointer advances.");
+}
+
+// ── Reset ──
+
+#[test]
+fn reg_reset_counter_zero() {
+    synth_hw("After reset, the counter is zero.");
+}
+
+#[test]
+fn reg_reset_deasserted_valid() {
+    synth_hw("After reset is deasserted, the signal is valid.");
+}
+
+#[test]
+fn reg_reset_output_never_high() {
+    synth_hw("The output is never high while reset is asserted.");
+}
+
+// ── Error Handling ──
+
+#[test]
+fn reg_error_parity_flag() {
+    synth_hw("If parity error is detected, the error flag is asserted.");
+}
+
+#[test]
+fn reg_error_overflow_status() {
+    synth_hw("If overflow is detected, the status bit is set.");
+}
+
+// ── Liveness ──
+
+#[test]
+fn reg_liveness_eventually_valid() {
+    let r = synth_hw("Eventually, every signal is valid.");
+    assert!(r.body.contains("s_eventually") || r.kind == "cover",
+        "Liveness should use s_eventually or cover. Got body: {}, kind: {}", r.body, r.kind);
+}
+
+#[test]
+fn reg_liveness_eventually_done() {
+    synth_hw("Eventually, every done is valid.");
+}
+
+#[test]
+fn reg_liveness_always_eventually_ready() {
+    synth_hw("Always, eventually every signal is ready.");
+}
+
+// ── Next-Cycle ──
+
+#[test]
+fn reg_next_signal_valid() {
+    let r = synth_hw("Next, every signal is valid.");
+    assert!(!r.body.is_empty(), "nexttime should produce non-empty body");
+}
+
+#[test]
+fn reg_next_grant_valid() {
+    synth_hw("Next, every grant is valid.");
+}
+
+// ── Until ──
+
+#[test]
+fn reg_until_request_grant() {
+    synth_hw("Every request holds until every grant holds.");
+}
+
+#[test]
+fn reg_until_signal_done() {
+    synth_hw("Every signal is valid until every done is valid.");
+}
+
+// ── Modal ──
+
+#[test]
+fn reg_modal_receiver_acknowledge() {
+    synth_hw("The receiver shall acknowledge every request.");
+}
+
+#[test]
+fn reg_modal_request_must_be_granted() {
+    synth_hw("Every request must be granted.");
+}
+
+#[test]
+fn reg_modal_signal_acknowledged() {
+    synth_hw("The signal must be acknowledged.");
+}
+
+// ── Conjunction / Disjunction ──
+
+#[test]
+fn reg_conjunction_request_and_grant() {
+    let r = synth_hw("Always, every request is valid and every grant is valid.");
+    assert!(r.body.contains("&&"), "Conjunction should produce &&. Got: {}", r.body);
+}
+
+#[test]
+fn reg_disjunction_request_or_grant() {
+    let r = synth_hw("Always, every request is valid or every grant is valid.");
+    assert!(r.body.contains("||"), "Disjunction should produce ||. Got: {}", r.body);
+}
+
+#[test]
+fn reg_conjunction_three_way() {
+    synth_hw("Always, every request is valid and every grant is valid and every signal is ready.");
+}
+
+// ── Negation ──
+
+#[test]
+fn reg_negation_not_every() {
+    let r = synth_hw("Always, not every signal is valid.");
+    assert!(r.body.contains("!") || r.body.contains("~"),
+        "Negation expected. Got: {}", r.body);
+}
+
+// ── NeoEvent / Action ──
+
+#[test]
+fn reg_neoevent_arbiter_grants() {
+    synth_hw("The arbiter grants the request.");
+}
+
+#[test]
+fn reg_neoevent_controller_enables() {
+    synth_hw("The controller enables the latch.");
+}
+
+// ── AssertionForge: Reset Propagation ──
+
+#[test]
+fn reg_af_reset_n_puc_rst() {
+    synth_hw("If reset_n is low, puc_rst is high in the next cycle.");
+}
+
+#[test]
+fn reg_af_reset_n_registers_invalid() {
+    synth_hw("If reset_n is low, every register is invalid.");
+}
+
+// ── AssertionForge: IRQ ──
+
+#[test]
+fn reg_af_irq_zero_ack_zero() {
+    synth_hw("If irq is zero, irq_ack is zero.");
+}
+
+#[test]
+fn reg_af_irq_not_asserted_ack_not() {
+    synth_hw("If irq is not asserted, irq_ack is not asserted.");
+}
+
+// ── AssertionForge: DMA ──
+
+#[test]
+fn reg_af_dma_en_addr_valid() {
+    synth_hw("If dma_en is asserted, dma_addr is valid.");
+}
+
+#[test]
+fn reg_af_dma_en_not_we_not() {
+    synth_hw("If dma_en is not asserted, dma_we is not asserted.");
+}
+
+// ── AssertionForge: APB ──
+
+#[test]
+fn reg_af_apb_psel_not_penable_not() {
+    synth_hw("If PSEL is not asserted, PENABLE is not asserted.");
+}
+
+#[test]
+fn reg_af_apb_penable_psel() {
+    synth_hw("If PENABLE is asserted, PSEL is asserted.");
+}
+
+// ── AssertionForge: UART ──
+
+#[test]
+fn reg_af_uart_tx_busy_no_new_data() {
+    synth_hw("If tx_busy is high, new_tx_data is not asserted.");
+}
+
+#[test]
+fn reg_af_uart_rx_valid_data() {
+    synth_hw("If rx_valid is asserted, rx_data is valid.");
+}
+
+// ── AssertionForge: AXI ──
+
+#[test]
+fn reg_af_axi_arvalid_araddr() {
+    synth_hw("If ARVALID is asserted, ARADDR is valid.");
+}
+
+#[test]
+fn reg_af_axi_rvalid_rdata() {
+    synth_hw("If RVALID is asserted, RDATA is valid.");
+}
+
+#[test]
+fn reg_af_axi_bvalid_bresp() {
+    synth_hw("If BVALID is asserted, BRESP is valid.");
+}
+
+// ── AssertionForge: SPI ──
+
+#[test]
+fn reg_af_spi_cs_low_clk_valid() {
+    synth_hw("If spi_cs is low, spi_clk is valid.");
+}
+
+#[test]
+fn reg_af_spi_cs_high_mosi_not() {
+    synth_hw("If spi_cs is high, spi_mosi is not asserted.");
+}
+
+// ── AssertionForge: Memory ──
+
+#[test]
+fn reg_af_mem_we_addr_valid() {
+    synth_hw("If mem_we is asserted, mem_addr is valid.");
+}
+
+#[test]
+fn reg_af_mem_read_write_mutex() {
+    synth_hw("Read and write are not both asserted.");
+}
+
+// ── AssertionForge: Delay specs (known_gap tagged but actually passing) ──
+
+#[test]
+fn reg_af_irq_ack_within_3() {
+    synth_hw("If irq is asserted, irq_ack is asserted within 3 cycles.");
+}
+
+#[test]
+fn reg_af_reset_deasserted_ready_3() {
+    synth_hw("If reset is deasserted, ready is asserted within 3 cycles.");
+}
+
+#[test]
+fn reg_af_wakeup_cpu_en_2() {
+    synth_hw("If wakeup is asserted, cpu_en is asserted within 2 cycles.");
+}
+
+#[test]
+fn reg_af_psel_penable_pready_1() {
+    synth_hw("If PSEL and PENABLE are asserted, PREADY follows within 1 cycle.");
+}
+
+#[test]
+fn reg_af_spi_cs_miso_1() {
+    synth_hw("If spi_cs is low, spi_miso is valid within 1 cycle.");
+}
+
+#[test]
+fn reg_af_mem_req_ack_4() {
+    synth_hw("If mem_req is asserted, mem_ack is asserted within 4 cycles.");
+}
+
+#[test]
+fn reg_af_sync_req_ack_3() {
+    synth_hw("If sync_req is asserted, sync_ack is asserted within 3 cycles.");
+}
+
+// ── AssertionForge: Stability / Pipeline ──
+
+#[test]
+fn reg_af_clk_en_register_holds() {
+    synth_hw("If clk_en is low, the register holds its value.");
+}
+
+#[test]
+fn reg_af_stall_register_holds() {
+    synth_hw("If stall is asserted, the register holds its value.");
+}
+
+#[test]
+fn reg_af_flush_valid_low_next() {
+    synth_hw("If flush is asserted, valid is low in the next cycle.");
+}
+
+#[test]
+fn reg_af_valid_stall_done_next() {
+    synth_hw("If valid is asserted and stall is not asserted, done is asserted in the next cycle.");
+}
+
+#[test]
+fn reg_af_enable_counter_holds() {
+    synth_hw("If enable is low, the counter holds its value.");
+}
+
+// ── AssertionForge: Power / Wakeup ──
+
+#[test]
+fn reg_af_dco_enable_wkup() {
+    synth_hw("If dco_enable is low and cpu_en is high, dco_wkup is asserted.");
+}
+
+// ── AssertionForge: UART nexttime ──
+
+#[test]
+fn reg_af_uart_tx_busy_next() {
+    synth_hw("If tx_busy is low and new_tx_data is asserted, tx_busy is asserted in the next cycle.");
+}
+
+// ── AssertionForge: AXI until ──
+
+#[test]
+fn reg_af_axi_awvalid_until_awready() {
+    synth_hw("If AWVALID is asserted, AWVALID remains asserted until AWREADY is asserted.");
+}
+
+// ── AssertionForge: AXI delay ──
+
+#[test]
+fn reg_af_axi_wvalid_bvalid_3() {
+    synth_hw("If WVALID and WREADY are asserted, BVALID is asserted within 3 cycles.");
+}
+
+// ── AssertionForge: APB until ──
+
+#[test]
+fn reg_af_apb_paddr_pwrite_until_penable() {
+    synth_hw("If PADDR is valid, PWRITE is stable until PENABLE is asserted.");
+}
+
+// ── AssertionForge: Arbiter ──
+
+#[test]
+fn reg_af_arbiter_grant_request_next() {
+    synth_hw("If grant is asserted and request is not asserted, grant is not asserted in the next cycle.");
+}
+
+// ── AssertionForge: Counter ──
+
+#[test]
+fn reg_af_counter_full_zero_next() {
+    synth_hw("If enable is high and the counter is full, the counter is zero in the next cycle.");
+}
+
+// ── Conditional negation ──
+
+#[test]
+fn reg_cond_negation_request_ack() {
+    synth_hw("If request is not asserted, acknowledge is not asserted.");
+}
+
+// ── Until + stability ──
+
+#[test]
+fn reg_until_valid_remains_until_ready() {
+    synth_hw("If valid is asserted, it remains asserted until ready is asserted.");
+}
+
+// ── Passive ──
+
+#[test]
+fn reg_passive_data_transferred() {
+    synth_hw("The data is transferred when valid and ready are both high.");
+}

--- a/crates/logicaffeine_tests/tests/phase_hw_gaps.rs
+++ b/crates/logicaffeine_tests/tests/phase_hw_gaps.rs
@@ -1,0 +1,567 @@
+//! Hardware Spec Gaps — RED Tests
+//!
+//! Comprehensive RED tests for all remaining gaps (A–H) identified in the
+//! hw-parser-gaps benchmark re-baseline. Each gap section contains tests
+//! covering parse acceptance, FOL structure, and SVA synthesis semantics.
+//!
+//! These tests define the spec. Implementation must make them GREEN without
+//! modifying any test in this file.
+
+use logicaffeine_compile::codegen_sva::fol_to_sva::{synthesize_sva_from_spec, SynthesizedSva};
+use logicaffeine_compile::codegen_sva::sva_model::parse_sva;
+use logicaffeine_language::compile;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// HELPERS
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Synthesize, assert parse success + non-degenerate + parseable SVA body.
+fn synth(spec: &str) -> SynthesizedSva {
+    let r = synthesize_sva_from_spec(spec, "clk")
+        .unwrap_or_else(|e| panic!("Synthesis failed for '{}': {}", spec, e));
+    assert!(
+        r.body.trim() != "0" && r.body.trim() != "1",
+        "Degenerate body for '{}': '{}'",
+        spec,
+        r.body
+    );
+    r
+}
+
+/// Assert that SVA body is parseable by the SVA model parser.
+fn assert_parseable_sva(r: &SynthesizedSva, spec: &str) {
+    let parse = parse_sva(&r.body);
+    assert!(
+        parse.is_ok(),
+        "Unparseable SVA for '{}': body='{}' err={:?}",
+        spec,
+        r.body,
+        parse.err()
+    );
+}
+
+/// Assert that signals were extracted (not empty).
+fn assert_signals_extracted(r: &SynthesizedSva, spec: &str) {
+    assert!(
+        !r.signals.is_empty(),
+        "No signals extracted for '{}': body='{}'",
+        spec,
+        r.body
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP A: CONSEQUENT EVENTUALLY
+//
+// "If request is asserted, grant is eventually asserted."
+//
+// The word "eventually" must work inside consequent clauses (after if),
+// not just sentence-initially. The SVA must produce a liveness implication:
+//   request |-> s_eventually(grant)
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_a_consequent_eventually_parses() {
+    let result = compile("If request is asserted, grant is eventually asserted.");
+    assert!(
+        result.is_ok(),
+        "\"eventually\" in consequent must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_a_consequent_eventually_synthesizes() {
+    let r = synth("If request is asserted, grant is eventually asserted.");
+    assert_parseable_sva(&r, "consequent eventually");
+}
+
+#[test]
+fn gap_a_consequent_eventually_produces_liveness() {
+    let r = synth("If request is asserted, grant is eventually asserted.");
+    assert!(
+        r.body.contains("s_eventually"),
+        "Consequent eventually must produce s_eventually in SVA body. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_a_consequent_eventually_produces_implication() {
+    let r = synth("If request is asserted, grant is eventually asserted.");
+    assert!(
+        r.body.contains("|->") || r.body.contains("|=>"),
+        "Must produce implication operator. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_a_consequent_eventually_has_both_signals() {
+    let r = synth("If request is asserted, grant is eventually asserted.");
+    assert_signals_extracted(&r, "consequent eventually");
+    let signals_lower: Vec<String> = r.signals.iter().map(|s| s.to_lowercase()).collect();
+    let has_request = signals_lower.iter().any(|s| s.contains("request"));
+    let has_grant = signals_lower.iter().any(|s| s.contains("grant"));
+    assert!(
+        has_request && has_grant,
+        "Must extract both request and grant signals. Got: {:?}",
+        r.signals
+    );
+}
+
+#[test]
+fn gap_a_consequent_eventually_is_cover_or_liveness() {
+    let r = synth("If request is asserted, grant is eventually asserted.");
+    // Liveness properties can be either assert with s_eventually or cover
+    assert!(
+        r.body.contains("s_eventually") || r.kind == "cover",
+        "Liveness implication should use s_eventually or be cover property. Got kind='{}' body='{}'",
+        r.kind,
+        r.body
+    );
+}
+
+// Variation: "always, if X, then eventually Y"
+#[test]
+fn gap_a_always_if_then_eventually() {
+    let r = synth("Always, if every request holds, then eventually, every grant holds.");
+    assert!(
+        r.body.contains("s_eventually"),
+        "Nested always-if-eventually must produce s_eventually. Got: '{}'",
+        r.body
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP B: WHILE AS TEMPORAL DURATION
+//
+// "While valid is asserted and ready is not asserted, data is stable."
+// "The transmitter shall not send data while idle."
+//
+// "while" introduces duration: Y must hold over the entire interval where
+// X is true, not just at the moment X becomes true.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_b_while_parses() {
+    let result = compile("While valid is asserted and ready is not asserted, data is stable.");
+    assert!(
+        result.is_ok(),
+        "\"While X, Y\" must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_b_while_synthesizes() {
+    let r = synth("While valid is asserted and ready is not asserted, data is stable.");
+    assert_parseable_sva(&r, "while stability");
+}
+
+#[test]
+fn gap_b_while_not_plain_implication() {
+    // While semantics must NOT collapse to a one-step implication.
+    // The SVA must express duration: the consequent holds throughout the condition.
+    let r = synth("While valid is asserted and ready is not asserted, data is stable.");
+    // Duration can be expressed as:
+    // - X throughout Y
+    // - X |-> (Y s_until !X)
+    // - (X && Y) style conjunction that holds at every cycle
+    // At minimum, the body must reference both the condition and the consequent
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("valid") && body_lower.contains("data"),
+        "While body must reference both condition (valid) and consequent (data). Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_b_while_extracts_signals() {
+    let r = synth("While valid is asserted and ready is not asserted, data is stable.");
+    assert_signals_extracted(&r, "while stability");
+}
+
+#[test]
+fn gap_b_while_postposed_parses() {
+    // "shall not send data while idle" — while appears after the main clause
+    let result = compile("The transmitter shall not send data while idle.");
+    assert!(
+        result.is_ok(),
+        "Postposed \"while\" must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_b_while_postposed_synthesizes() {
+    let r = synth("The transmitter shall not send data while idle.");
+    assert_parseable_sva(&r, "postposed while");
+}
+
+#[test]
+fn gap_b_while_simple() {
+    // Simpler while case
+    let r = synth("While reset is asserted, the output is low.");
+    assert_parseable_sva(&r, "simple while");
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("reset") && body_lower.contains("output"),
+        "While body must reference condition and consequent. Got: '{}'",
+        r.body
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP C: AFTER X, Y WITHIN N CYCLES
+//
+// "After request, grant follows within 3 cycles."
+//
+// This tests the combination of after-subordinator with bounded temporal
+// follow. Must NOT reduce to plain implication — must preserve the bound.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_c_after_follows_within_parses() {
+    let result = compile("After request, grant follows within 3 cycles.");
+    assert!(
+        result.is_ok(),
+        "\"After X, Y follows within N cycles\" must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_c_after_follows_within_synthesizes() {
+    let r = synth("After request, grant follows within 3 cycles.");
+    assert_parseable_sva(&r, "after follows within");
+}
+
+#[test]
+fn gap_c_after_follows_within_has_bound() {
+    let r = synth("After request, grant follows within 3 cycles.");
+    // The SVA body must contain a bounded delay: ##[0:3] or ##[1:3]
+    assert!(
+        r.body.contains("##") || r.body.contains("[0:3]") || r.body.contains("[1:3]"),
+        "After+within must produce bounded delay in SVA. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_c_after_follows_within_extracts_signals() {
+    let r = synth("After request, grant follows within 3 cycles.");
+    assert_signals_extracted(&r, "after follows within");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP D: COUNTING QUANTIFIER WITH EXPLICIT LIST
+//
+// "At most one of grant0, grant1, and grant2 is asserted."
+//
+// The parser must handle "of" + comma-separated signal list after
+// counting quantifiers, producing $onehot0 over the listed signals.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_d_counting_of_list_parses() {
+    let result = compile("At most one of grant0, grant1, and grant2 is asserted.");
+    assert!(
+        result.is_ok(),
+        "Counting quantifier with 'of' + list must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_d_counting_of_list_synthesizes() {
+    let r = synth("At most one of grant0, grant1, and grant2 is asserted.");
+    assert_parseable_sva(&r, "counting of list");
+}
+
+#[test]
+fn gap_d_counting_of_list_produces_onehot() {
+    let r = synth("At most one of grant0, grant1, and grant2 is asserted.");
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("onehot0") || body_lower.contains("onehot"),
+        "At-most-one of list should produce $onehot0. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_d_counting_of_list_contains_all_signals() {
+    let r = synth("At most one of grant0, grant1, and grant2 is asserted.");
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("grant0") && body_lower.contains("grant1") && body_lower.contains("grant2"),
+        "SVA body must reference all listed signals. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_d_counting_of_list_extracts_signals() {
+    let r = synth("At most one of grant0, grant1, and grant2 is asserted.");
+    assert_signals_extracted(&r, "counting of list");
+}
+
+// Two-element list
+#[test]
+fn gap_d_counting_of_two_elements() {
+    let result = compile("At most one of read and write is asserted.");
+    assert!(
+        result.is_ok(),
+        "Counting with two-element list must parse: {:?}",
+        result.err()
+    );
+}
+
+// Exactly-one variant
+#[test]
+fn gap_d_exactly_one_of_list() {
+    let result = compile("Exactly one of grant0, grant1, and grant2 is asserted.");
+    assert!(
+        result.is_ok(),
+        "Exactly-one of list must parse: {:?}",
+        result.err()
+    );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP E: COUNTING QUANTIFIER + PASSIVE PREDICATE
+//
+// "At most one request is granted at any time."
+//
+// Counting quantifier with passive voice predicate must work correctly.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_e_counting_passive_parses() {
+    let result = compile("At most one request is granted at any time.");
+    assert!(
+        result.is_ok(),
+        "Counting + passive must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_e_counting_passive_synthesizes() {
+    let r = synth("At most one request is granted at any time.");
+    assert_parseable_sva(&r, "counting passive");
+}
+
+#[test]
+fn gap_e_counting_passive_produces_onehot() {
+    let r = synth("At most one request is granted at any time.");
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("onehot0") || body_lower.contains("countones"),
+        "Counting+passive should produce $onehot0 or $countones. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_e_counting_passive_extracts_signals() {
+    let r = synth("At most one request is granted at any time.");
+    assert_signals_extracted(&r, "counting passive");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP F: SIGNAL EXTRACTION FOR COUNTING SVAs
+//
+// These specs already synthesize valid SVA but extract zero signals.
+// The signal extractor must inspect $onehot0(...) / $countones(...) args.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_f_at_most_one_signal_extracts() {
+    let r = synth("At most one signal is valid.");
+    assert_signals_extracted(&r, "at most one signal");
+}
+
+#[test]
+fn gap_f_at_most_one_grant_extracts() {
+    let r = synth("At most one grant is valid.");
+    assert_signals_extracted(&r, "at most one grant");
+}
+
+#[test]
+fn gap_f_at_most_two_signals_extracts() {
+    let r = synth("At most two signals are valid.");
+    assert_signals_extracted(&r, "at most two signals");
+}
+
+#[test]
+fn gap_f_at_least_one_signal_extracts() {
+    let r = synth("At least one signal is valid.");
+    assert_signals_extracted(&r, "at least one signal");
+}
+
+#[test]
+fn gap_f_at_least_two_signals_extracts() {
+    let r = synth("At least two signals are valid.");
+    assert_signals_extracted(&r, "at least two signals");
+}
+
+#[test]
+fn gap_f_at_most_one_grant_asserted_extracts() {
+    let r = synth("At most one grant is asserted at any time.");
+    assert_signals_extracted(&r, "at most one grant asserted");
+}
+
+#[test]
+fn gap_f_at_most_one_request_granted_extracts() {
+    // This is also Gap E — but the signal extraction aspect is Gap F
+    let r = synth("At most one request is granted at any time.");
+    assert_signals_extracted(&r, "at most one request granted");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP G: NEOEVENT / ACTION SENTENCE TAXONOMY
+//
+// "The bus acknowledges the request."
+//
+// This is an action sentence, not a temporal property. It currently
+// degenerates to body="0". The system should either:
+// 1. Reject with a structured error explaining why
+// 2. Reclassify as not_a_property
+// 3. Provide a real property interpretation
+//
+// We test for option 1 or 3: it must not silently degenerate.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_g_neoevent_does_not_degenerate() {
+    let result = synthesize_sva_from_spec("The bus acknowledges the request.", "clk");
+    match result {
+        Ok(r) => {
+            assert!(
+                r.body.trim() != "0",
+                "NeoEvent must not degenerate to '0'. Either synthesize or reject explicitly. Got body: '{}'",
+                r.body
+            );
+        }
+        Err(e) => {
+            // Explicit rejection is acceptable — but it should indicate
+            // this is not a property, not just a generic parse error
+            assert!(
+                e.to_lowercase().contains("property")
+                    || e.to_lowercase().contains("action")
+                    || e.to_lowercase().contains("not a")
+                    || e.to_lowercase().contains("temporal"),
+                "Rejection message should explain why this is not a property. Got: '{}'",
+                e
+            );
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GAP H: NEVER UNKNOWN IN CONSEQUENT
+//
+// "If dma_en and dma_we are asserted, dma_din is never unknown."
+// "If smclk_en and cpu_en are asserted, smclk is never unknown."
+//
+// The word "never" must work in consequent clauses, and "unknown" must
+// be recognized as a valid adjective/predicate.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn gap_h_never_unknown_parses() {
+    let result = compile("If dma_en and dma_we are asserted, dma_din is never unknown.");
+    assert!(
+        result.is_ok(),
+        "\"never unknown\" in consequent must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_h_never_unknown_synthesizes() {
+    let r = synth("If dma_en and dma_we are asserted, dma_din is never unknown.");
+    assert_parseable_sva(&r, "never unknown dma");
+}
+
+#[test]
+fn gap_h_never_unknown_has_negation() {
+    let r = synth("If dma_en and dma_we are asserted, dma_din is never unknown.");
+    let body_lower = r.body.to_lowercase();
+    assert!(
+        body_lower.contains("!") || body_lower.contains("~") || body_lower.contains("not"),
+        "\"never unknown\" must produce negation in SVA. Got: '{}'",
+        r.body
+    );
+}
+
+#[test]
+fn gap_h_never_unknown_extracts_signals() {
+    let r = synth("If dma_en and dma_we are asserted, dma_din is never unknown.");
+    assert_signals_extracted(&r, "never unknown dma");
+    let signals_lower: Vec<String> = r.signals.iter().map(|s| s.to_lowercase()).collect();
+    let has_dma_en = signals_lower.iter().any(|s| s.contains("dma_en"));
+    let has_dma_din = signals_lower.iter().any(|s| s.contains("dma_din"));
+    assert!(
+        has_dma_en && has_dma_din,
+        "Must extract dma_en and dma_din signals. Got: {:?}",
+        r.signals
+    );
+}
+
+#[test]
+fn gap_h_never_unknown_variant_smclk() {
+    let result = compile("If smclk_en and cpu_en are asserted, smclk is never unknown.");
+    assert!(
+        result.is_ok(),
+        "smclk variant must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn gap_h_never_unknown_variant_smclk_synthesizes() {
+    let r = synth("If smclk_en and cpu_en are asserted, smclk is never unknown.");
+    assert_parseable_sva(&r, "never unknown smclk");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BONUS: NOT-BOTH MUTEX (discovered in baseline as additional parse-fail)
+//
+// "Always, not both every request is valid and every grant is valid."
+//
+// This was not in the original gap list but showed up as PARSE-FAIL.
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn bonus_not_both_parses() {
+    let result = compile("Always, not both every request is valid and every grant is valid.");
+    assert!(
+        result.is_ok(),
+        "\"not both X and Y\" must parse: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn bonus_not_both_synthesizes() {
+    let r = synth("Always, not both every request is valid and every grant is valid.");
+    assert_parseable_sva(&r, "not both mutex");
+}
+
+#[test]
+fn bonus_not_both_produces_negated_conjunction() {
+    let r = synth("Always, not both every request is valid and every grant is valid.");
+    let body_lower = r.body.to_lowercase();
+    // "not both A and B" = !(A && B) = !A || !B
+    assert!(
+        (body_lower.contains("!") && body_lower.contains("&&"))
+            || body_lower.contains("||")
+            || body_lower.contains("nand"),
+        "Not-both should produce negated conjunction or NAND. Got: '{}'",
+        r.body
+    );
+}


### PR DESCRIPTION
## Summary

- **Gap 1:** Add bit as a noun in the lexicon and disambiguate it from the verb bite
- **Gap 2:** Add shall to the modal verb check gate (IEEE deontic standard)
- **Gap 3:** Handle is always / is never as temporal copula modifiers
- **Gap 4:** Parse sentence-initial after / before as temporal subordinators
- **Gap 5:** Allow and-conjunctions of copula clauses in conditional antecedents
- **Gap 6:** Parse when / whenever as conditional subordinators rather than wh-questions
- **Gap 7:** Add SVA synthesizer match arms for Aspectual, Voice, Relation, Atom, Identity, Categorical, Scopal, and Causal
- **Gap 8:** Add counting quantifier SVA synthesis (AtMost -> $onehot0, AtLeast -> OR, Cardinal -> $onehot)
- **Gap 9:** Add copula lookahead in the lexer to disambiguate noun / verb readings for request and grant

Projected improvement: 21% -> 81% end-to-end success on the 48-sentence hardware spec benchmark.

## Test plan

- 85 new / extended tests across 3 files (phase_hw_lexicon, phase_hw_parser_gaps, phase_hw_fol_to_sva)
- Full regression suite: 371 test files, 0 failures
- All regression guard sentences verified (reset / valid conditionals, read / write mutex, never-before-verb, must-modal)

## Spec

See assertion_forge_logos/HARDWARE_PARSER_GAPS_SPEC.md for the full implementation spec and gap analysis.